### PR TITLE
Keep up to date with python-codicefiscale

### DIFF
--- a/random_italian_person/random_italian_person.py
+++ b/random_italian_person/random_italian_person.py
@@ -70,9 +70,9 @@ class RandomItalianPerson:
         }
 
         self._data["codice_fiscale"] = codicefiscale.encode(
-            surname=self.surname,
-            name=self.name,
-            sex=self.sex,
+            lastname=self.surname,
+            firstname=self.name,
+            gender=self.sex,
             birthdate=self.birthdate,
             birthplace=self.birthplace
         )


### PR DESCRIPTION
This is a fix to this error since python-codicefiscale changed some parameters names:
```
self._data["codice_fiscale"] = codicefiscale.encode(
TypeError: encode() got an unexpected keyword argument 'surname'
```